### PR TITLE
dumb attempt to find relevant connection

### DIFF
--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -5,7 +5,7 @@ import json
 import re
 from time import time
 from explorer import app_settings
-from django.db import connections, connection, models, transaction, DatabaseError
+from django.db import connections, connection, router, models, transaction, DatabaseError
 from django.http import HttpResponse
 
 EXPLORER_PARAM_TOKEN = "$$"
@@ -19,7 +19,15 @@ def passes_blacklist(sql):
 
 
 def execute_query(sql):
-    conn = connections[app_settings.EXPLORER_CONNECTION_NAME] if app_settings.EXPLORER_CONNECTION_NAME else connection
+    conn = None
+    apps = [a for a in models.get_apps() if a.__package__ not in app_settings.EXPLORER_SCHEMA_EXCLUDE_APPS]
+    for app in apps:
+        for model in models.get_models(app):
+            if model._meta.db_table in sql:
+                conn = connections[router.db_for_read(model)]
+    if conn is None:
+        conn = connections[app_settings.EXPLORER_CONNECTION_NAME] if app_settings.EXPLORER_CONNECTION_NAME\
+            else connection
     cursor = conn.cursor()
     start_time = time()
 


### PR DESCRIPTION
If you're using django database routers and multiple databases/connections then the choice of "always use default" or "always use EXPLORER_CONNECTION_NAME" is a bit restrictive.

This change does a Very Dumb Check to see if the table name for any known model appears in the SQL to be executed.  It doesn't parse the SQL- it doesn't even split it into words, so it could find a table name in a constant or a column name or a partial match of some other table name, or anywhere.  If it finds it then it uses the connection for database reads on that model.

I guess a new SETTING to enable/disable this behaviour would be good.  Also some basic parsing to target real table names in queries .. does django have some built-in basic SQL parsing utilities?  Perhaps there's a python library we could use?