### PR TITLE
Use url template tag instead of relative urls

### DIFF
--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -38,7 +38,7 @@
             <div class="navbar navbar-default navbar-static-top" role="navigation">
               <div class="container">
                 <div class="navbar-header">
-                  <a class="navbar-brand" href="../">SQL Explorer</a>
+                  <a class="navbar-brand" href="{% url "explorer_index" %}">SQL Explorer</a>
                 </div>
                 <div class="navbar-collapse collapse">
                   <ul class="nav navbar-nav">

--- a/explorer/templates/explorer/play.html
+++ b/explorer/templates/explorer/play.html
@@ -1,10 +1,12 @@
 {% extends "explorer/base.html" %}
 
+{% load url from future %}
+
 {% block sql_explorer_navlinks %}
     {% if can_change %}
-      <li><a href="../new/">New Query</a></li>
-      <li class="active"><a href="#">Playground</a></li>
-      <li><a href="../logs/">Logs</a></li>
+      <li><a href="{% url "query_create" %}">New Query</a></li>
+      <li class="active"><a href="">Playground</a></li>
+      <li><a href="{% url "explorer_logs" %}">Logs</a></li>
     {% endif %}
 {% endblock %}
 
@@ -13,7 +15,7 @@
     <div id="query_area" class="col-md-12">
         <h2>Playground</h2>
         <p>The playground is for experimenting and writing ad-hoc queries. By default, nothing you do here will be saved.</p>
-        <form role="form" action="../play/" method="post" id="editor">{% csrf_token %}
+        <form role="form" action="{% url "explorer_playground" %}" method="post" id="editor">{% csrf_token %}
             {% if error %}
                 <div class="alert alert-danger">{{ error|escape }}</div>
             {% endif %}

--- a/explorer/templates/explorer/query.html
+++ b/explorer/templates/explorer/query.html
@@ -3,11 +3,11 @@
 
 {% block sql_explorer_navlinks %}
     {% if can_change %}
-      <li{% if not query %} class="active" {% endif %}><a href="../new/">New Query</a></li>
-      <li><a href="../play/">Playground</a></li>
+      <li{% if not query %} class="active" {% endif %}><a href="{% url "query_create" %}">New Query</a></li>
+      <li><a href="{% url "explorer_playground" %}">Playground</a></li>
     {% endif %}
     {% if query %}<li class="active"><a href="">Query Detail</a></li>{% endif %}
-    <li><a href="../logs/">Logs</a></li>
+    <li><a href="{% url "explorer_logs" %}">Logs</a></li>
 {% endblock %}
 
 {% block sql_explorer_content %}
@@ -19,7 +19,11 @@
             <div class="alert alert-info">{{ message }}</div>
         {% endif %}
         <div>
-            <form role="form" class="form-horizontal" action="../{% firstof query.id 'new' %}/" method="post" id="editor">{% csrf_token %}
+            {% if query %}
+                <form role="form" class="form-horizontal" action="{% url "query_detail" query.id %}" method="post" id="editor">{% csrf_token %}
+            {% else %}
+                <form role="form" class="form-horizontal" action="{% url "query_create" %}" method="post" id="editor">{% csrf_token %}
+            {% endif %}
                 {% if error %}
                     <div class="alert alert-danger">{{ error|escape }}</div>
                 {% endif %}
@@ -73,7 +77,7 @@
                             {% if can_change %}
                                 <input type="submit" value="Save & Run" class="btn btn-default" id="save_button" />
                                 {% if query %}
-                                     <button class="btn btn-default download_button" href="csv">Download CSV</button>
+                                     <button class="btn btn-default download_button" href="{% url "query_csv" query.id %}">Download CSV</button>
                                      <input type="submit" value="Open in Playground" class="btn btn-default" id="playground_button"/>
                                 {%  endif %}
                                 <button type="button" class="btn btn-default" id="show_schema_button">Show Schema</button>
@@ -81,7 +85,7 @@
                                 <button type="button" class="btn btn-default" id="format_button">Format</button>
                             {% else %}
                                 <input type="submit" value="Refresh" class="btn btn-default" id="refresh_button" />
-                                <button class="btn btn-default download_button" href="csv">Download CSV</button>
+                                <button class="btn btn-default download_button" href="{% url "query_csv" query.id %}">Download CSV</button>
                             {% endif %}
                         </div>
                     </div>

--- a/explorer/templates/explorer/query_list.html
+++ b/explorer/templates/explorer/query_list.html
@@ -1,10 +1,12 @@
 {% extends "explorer/base.html" %}
 
+{% load url from future %}
+
 {% block sql_explorer_navlinks %}
     {% if can_change %}
-      <li><a href="new/">New Query</a></li>
-      <li><a href="play/">Playground</a></li>
-      <li><a href="logs/">Logs</a></li>
+      <li><a href="{% url "query_create" %}">New Query</a></li>
+      <li><a href="{% url "explorer_playground" %}">Playground</a></li>
+      <li><a href="{% url "explorer_logs" %}">Logs</a></li>
     {% endif %}
 {% endblock %}
 
@@ -22,10 +24,10 @@
             <tbody>
                 {% for object in recent_queries %}
                 <tr>
-                    <td><a href="{{ object.id }}/">{{ object }}</a></td>
+                    <td><a href="{% url "query_detail" object.id %}">{{ object }}</a></td>
                     <td>{{ object.last_run_date|date:"SHORT_DATETIME_FORMAT" }}</td>
                     <td class="icon-cell">
-                        <a href="{{ object.id }}/download"><i class="glyphicon glyphicon-download"></i></a>
+                        <a href="{% url "query_download" object.id %}"><i class="glyphicon glyphicon-download"></i></a>
                     </td>
                 </tr>
                 {% endfor %}
@@ -61,7 +63,7 @@
                     </td>
                 {% else %}
                     <td class="name" {% if object.is_in_category %}class="indented"{% endif %}>
-                        {% if object.is_in_category %}|-- {% endif %}<a href="{{ object.id }}/">{{ object.title }}</a>
+                        {% if object.is_in_category %}|-- {% endif %}<a href="{% url "query_detail" object.id %}">{{ object.title }}</a>
                     </td>
                     <td>{{ object.created_at|date:"SHORT_DATE_FORMAT" }}
                         {% if object.created_by_user %}
@@ -69,14 +71,14 @@
                         {% endif %}
                     </td>
                     <td class="icon-cell">
-                        <a href="{{ object.id }}/download"><i class="glyphicon glyphicon-download"></i></a>
+                        <a href="{% url "query_download" object.id %}"><i class="glyphicon glyphicon-download"></i></a>
                     </td>
                     {% if can_change %}
                         <td class="icon-cell">
-                            <a href="play/?query_id={{ object.id }}"><i class="glyphicon glyphicon-new-window"></i></a>
+                            <a href="{% url "explorer_playground" %}?query_id={{ object.id }}"><i class="glyphicon glyphicon-new-window"></i></a>
                         </td>
                         <td class="icon-cell">
-                            <a href="{{ object.id }}/delete"><i class="glyphicon glyphicon-trash"></i></a>
+                            <a href="{% url "query_delete" object.id %}"><i class="glyphicon glyphicon-trash"></i></a>
                         </td>
                     {% endif %}
                     <td>

--- a/explorer/templates/explorer/querylog_list.html
+++ b/explorer/templates/explorer/querylog_list.html
@@ -1,10 +1,12 @@
 {% extends "explorer/base.html" %}
 
+{% load url from future %}
+
 {% block sql_explorer_navlinks %}
     {% if can_change %}
-      <li><a href="../new/">New Query</a></li>
-      <li><a href="../play/">Playground</a></li>
-      <li><a class="active" href="../logs/">Logs</a></li>
+      <li><a href="{% url "query_create" %}">New Query</a></li>
+      <li><a href="{% url "explorer_playground" %}">Playground</a></li>
+      <li class="active"><a href="">Logs</a></li>
     {% endif %}
 {% endblock %}
 
@@ -26,8 +28,8 @@
                 <td>{{ object.run_at|date:"SHORT_DATETIME_FORMAT" }}</td>
                 <td>{{ object.run_by_user.email }}</td>
                 <td class="log-sql">{{ object.sql }}</td>
-                <td> {% if object.query_id %}<a href="../{{object.query_id}}/">Query {{ object.query_id }}</a>{% elif object.is_playground %}Playground{% else %}--{% endif %}</td>
-                <td><a href="../play/?querylog_id={{ object.id }}">Open</a></td>
+                <td> {% if object.query_id %}<a href="{% url "query_detail" object.query_id %}">Query {{ object.query_id }}</a>{% elif object.is_playground %}Playground{% else %}--{% endif %}</td>
+                <td><a href="{% url "explorer_playground" %}?querylog_id={{ object.id }}">Open</a></td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
This originally started as a fix for the link in the navbar brand (it is currently '../' so on the main query list it takes you out of the explorer), but I went ahead and went through updating any URLs I found in the templates to use the `url` template tag. It makes it easier for end users to customize the URLs via the urlconf without having all of the templates break.

There are still hardcoded URLs in `explorer.js` but those are trickier to change.