### PR TITLE
Fixing missing semicolon

### DIFF
--- a/explorer/static/explorer/explorer.css
+++ b/explorer/static/explorer/explorer.css
@@ -84,7 +84,7 @@
 
 .icon-cell {
     padding: 2px 0 0 45px;
-    vertical-align: middle
+    vertical-align: middle;
 }
 
 .icon-cell a {


### PR DESCRIPTION
Missing semicolon in `explorer.css`