### PR TITLE
Removed deprecated future url template tag for Django 1.9

### DIFF
--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load staticfiles %}
 <!DOCTYPE html>
 <html>

--- a/explorer/templates/explorer/play.html
+++ b/explorer/templates/explorer/play.html
@@ -1,7 +1,5 @@
 {% extends "explorer/base.html" %}
 
-{% load url from future %}
-
 {% block sql_explorer_navlinks %}
     {% if can_change %}
       <li><a href="{% url "query_create" %}">New Query</a></li>

--- a/explorer/templates/explorer/query.html
+++ b/explorer/templates/explorer/query.html
@@ -1,5 +1,4 @@
 {% extends "explorer/base.html" %}
-{% load url from future %}
 
 {% block sql_explorer_navlinks %}
     {% if can_change %}

--- a/explorer/templates/explorer/query_list.html
+++ b/explorer/templates/explorer/query_list.html
@@ -1,6 +1,5 @@
 {% extends "explorer/base.html" %}
 {% load staticfiles %}
-{% load url from future %}
 
 {% block sql_explorer_navlinks %}
     {% if can_change %}

--- a/explorer/templates/explorer/querylog_list.html
+++ b/explorer/templates/explorer/querylog_list.html
@@ -1,7 +1,5 @@
 {% extends "explorer/base.html" %}
 
-{% load url from future %}
-
 {% block sql_explorer_navlinks %}
     {% if can_change %}
       <li><a href="{% url "query_create" %}">New Query</a></li>


### PR DESCRIPTION
When running under Django 1.9, the following exception was being thrown: `TemplateSyntaxError: 'url' is not a valid tag or filter in tag library 'future'`

The new url tag syntax has been with us since Django 1.5, and django-sql-explorer claims to only support Django 1.6+, so the solution was to simply remove the offending import in the templates.