### PR TITLE
Add unsaved changes message

### DIFF
--- a/explorer/static/explorer/explorer.js
+++ b/explorer/static/explorer/explorer.js
@@ -27,6 +27,9 @@ function ExplorerEditor(queryId, dataUrl) {
             "Cmd-Enter": function() { this.doCodeMirrorSubmit(); }.bind(this)
         }
     });
+    this.editor.on("change", function(cm, change) {
+        document.getElementById('id_sql').classList.add('changed-input');
+    });
     this.bind();
 }
 
@@ -234,3 +237,16 @@ ExplorerEditor.prototype.bind = function() {
         if(event.keyCode == 13){ this.showRows(); }
     }.bind(this));
 };
+
+$(window).on('beforeunload', function () {
+    // Only do this if changed-input is on the page and we're not on the playground page.
+    if ($('.changed-input').length && !$('.playground-form').length) {
+        return 'You have unsaved changes to your query.';
+    }
+});
+
+// Disable unsaved changes warning when submitting the editor form
+$(document).on("submit", "#editor", function(event){
+    // disable warning
+    $(window).off('beforeunload');
+});

--- a/explorer/templates/explorer/play.html
+++ b/explorer/templates/explorer/play.html
@@ -13,7 +13,7 @@
     <div id="query_area" class="col-md-12">
         <h2>Playground</h2>
         <p>The playground is for experimenting and writing ad-hoc queries. By default, nothing you do here will be saved.</p>
-        <form role="form" action="{% url "explorer_playground" %}" method="post" id="editor">{% csrf_token %}
+        <form role="form" action="{% url "explorer_playground" %}" method="post" id="editor" class="playground-form">{% csrf_token %}
             {% if error %}
                 <div class="alert alert-danger">{{ error|escape }}</div>
             {% endif %}


### PR DESCRIPTION
Fixes #45 

A "You have unsaved changes" message pops up if the user has changed the SQL. It only pops up if they try to go to another page but not if they click the "Save and Run" button. Also, it doesn't pop up when you change the SQL on a playground and then go to another page. I figured the playground isn't usually for saving queries anyway, so why annoy the user?

Here's what it looks like:

<img width="1158" alt="screenshot 2016-01-05 22 28 06" src="https://cloud.githubusercontent.com/assets/4023140/12135086/29ce1aba-b3fc-11e5-928a-aaf008c6afef.png">
