### PR TITLE
Add missing migration for Django version prior 1.6

### DIFF
--- a/explorer/south_migrations/0005_auto__add_field_query_snapshot__del_field_querylog_is_playground__chg_.py
+++ b/explorer/south_migrations/0005_auto__add_field_query_snapshot__del_field_querylog_is_playground__chg_.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Query.snapshot'
+        db.add_column('explorer_query', 'snapshot',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Deleting field 'QueryLog.is_playground'
+        db.delete_column('explorer_querylog', 'is_playground')
+
+
+        # Changing field 'QueryLog.sql'
+        db.alter_column('explorer_querylog', 'sql', self.gf('django.db.models.fields.TextField')(null=True))
+
+    def backwards(self, orm):
+        # Deleting field 'Query.snapshot'
+        db.delete_column('explorer_query', 'snapshot')
+
+        # Adding field 'QueryLog.is_playground'
+        db.add_column('explorer_querylog', 'is_playground',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+        # Changing field 'QueryLog.sql'
+        db.alter_column('explorer_querylog', 'sql', self.gf('django.db.models.fields.TextField')(default=''))
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'unique': 'True'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'symmetrical': 'False', 'to': "orm['auth.Permission']"})
+        },
+        'auth.permission': {
+            'Meta': {'unique_together': "(('content_type', 'codename'),)", 'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'blank': 'True', 'max_length': '75'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'user_set'", 'symmetrical': 'False', 'to': "orm['auth.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'blank': 'True', 'max_length': '30'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'user_set'", 'symmetrical': 'False', 'to': "orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30', 'unique': 'True'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'db_table': "'django_content_type'", 'object_name': 'ContentType'},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'explorer.query': {
+            'Meta': {'ordering': "['title']", 'object_name': 'Query'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'auto_now_add': 'True'}),
+            'created_by_user': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['auth.User']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_run_date': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'auto_now': 'True'}),
+            'snapshot': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sql': ('django.db.models.fields.TextField', [], {}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'explorer.querylog': {
+            'Meta': {'ordering': "['-run_at']", 'object_name': 'QueryLog'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'query': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['explorer.Query']", 'on_delete': 'models.SET_NULL'}),
+            'run_at': ('django.db.models.fields.DateTimeField', [], {'blank': 'True', 'auto_now_add': 'True'}),
+            'run_by_user': ('django.db.models.fields.related.ForeignKey', [], {'null': 'True', 'blank': 'True', 'to': "orm['auth.User']"}),
+            'sql': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['explorer']

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -87,7 +87,7 @@ def write_csv(headers, data):
     writer = csv.writer(csv_data, delimiter=app_settings.CSV_DELIMETER)
     writer.writerow(headers)
     for row in data:
-        writer.writerow(row)
+        writer.writerow([s.decode('utf-8') for s in row])
     return csv_data.getvalue()
 
 


### PR DESCRIPTION
I have a project currently using Django 1.6.11, but the `south_migrations` lacks of new migration like `snapshot` field and `is_playgound` is still remained.

This PR add a missing south migration for older Django.