### PR TITLE
Changed icon url to be protocol relative.

### DIFF
--- a/explorer/static/explorer/explorer.css
+++ b/explorer/static/explorer/explorer.css
@@ -92,7 +92,7 @@
 }
 
 span.sort {
-    background: url('http://cdn.datatables.net/1.10.0/images/sort_both.png') no-repeat;
+    background: url('//cdn.datatables.net/1.10.0/images/sort_both.png') no-repeat;
     cursor: pointer;
     padding-left: 20px;
 }


### PR DESCRIPTION
The sort_both icon should be obtained through https when the page is loaded through https.